### PR TITLE
[Release 2.3.0] Update to api level 26 and build tools 26.0.2 (#2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+## VERSION 2.3.0
+
+_2_11_2017_
+
+* New: Support for Android SDK 26.
+
+## VERSION 2.2.0
+
+_20_10_2017_
+
+* New: MercadoPago Payment Experience SDK Tracking Library.

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,6 +16,9 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com'
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,8 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+build_tools_version = 26.0.2
+min_api_level = 14
+api_level = 26
+support_library_version = 26.0.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Tue Oct 31 10:59:07 ART 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/tracking/build.gradle
+++ b/tracking/build.gradle
@@ -1,13 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    publishNonDefault true
-    compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    compileSdkVersion api_level.toInteger()
+    buildToolsVersion build_tools_version
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 25
+        minSdkVersion min_api_level.toInteger()
+        targetSdkVersion api_level.toInteger()
         versionCode 1
         versionName "1.0"
 
@@ -21,7 +20,7 @@ android {
         }
         debug {
             testCoverageEnabled true
-            multiDexEnabled true
+            multiDexEnabled false
             versionNameSuffix " Debug"
             debuggable true
         }
@@ -33,11 +32,15 @@ android {
         }
     }
 
+    flavorDimensions "environment"
+
     productFlavors {
         dev {
+            dimension "environment"
             buildConfigField "String", "API_VERSION", "\"beta\""
         }
         prod {
+            dimension "environment"
             buildConfigField "String", "API_VERSION", "\"v1\""
         }
     }
@@ -50,14 +53,14 @@ project.gradle.taskGraph.whenReady {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.0.1'
-    testCompile 'junit:junit:4.12'
-    compile 'com.squareup.retrofit2:retrofit:2.1.0'
-    compile 'com.squareup.okhttp3:logging-interceptor:3.5.0'
-    compile 'com.google.code.gson:gson:2.7'
-    compile 'com.squareup.retrofit2:converter-gson:2.1.0'
+    testImplementation 'junit:junit:4.12'
+    implementation "com.android.support:appcompat-v7:$support_library_version"
+    implementation "com.squareup.retrofit2:retrofit:2.1.0"
+    implementation "com.squareup.okhttp3:logging-interceptor:3.5.0"
+    implementation "com.google.code.gson:gson:2.7"
+    implementation "com.squareup.retrofit2:converter-gson:2.1.0"
 }


### PR DESCRIPTION
Gradle configuration updated to api level 26 and build tools 26.0.2.

* Support library 26.0.2 updated.
* Gradle updated to 4.1.
* Gradle android plugin updated to 3.0.0.
* Android studio 3.0.0 update required.